### PR TITLE
fix: TS diagnostic in events middleware and TextField prop binding order

### DIFF
--- a/api/src/lib/middleware/events.ts
+++ b/api/src/lib/middleware/events.ts
@@ -3,7 +3,9 @@ import { Events } from "#services/Events"
 import { makeSSE } from "@effect-app/infra/middlewares"
 import * as Effect from "effect-app/Effect"
 
+// @effect-diagnostics effect/returnEffectInGen:off
 export const makeEvents = Effect.gen(function*() {
   const events = yield* Events
+
   return makeSSE(ClientEvents)(events.stream)
 })

--- a/frontend/components/TextField.vue
+++ b/frontend/components/TextField.vue
@@ -1,7 +1,7 @@
 <template>
   <v-text-field
-    :type="field.type === 'float' || field.type === 'int' ? 'number' : 'text'"
     v-bind="$props"
+    :type="field.type === 'float' || field.type === 'int' ? 'number' : 'text'"
     :model-value="convertIn(props.modelValue as any, field.type)"
     :required="field.metadata.required"
     :rules="props.extraRules ? [...props.extraRules, ...field.rules] : field.rules"


### PR DESCRIPTION
## What

Two small fixes found while getting the boilerplate to compile cleanly.

**`api/src/lib/middleware/events.ts`** — `makeEvents` is meant to *return* the SSE `Effect<HttpServerResponse>` so callers `yield*` it in their own gen (see `router.ts`, where `handleEvents.pipe(Effect.tapCause(...))` needs an `Effect`). The `effect/returnEffectInGen` diagnostic flags this intentional pattern; suppressing it keeps `return makeSSE(...)` and fixes the `TS2345` at `router.ts:74` (a bare `HttpServerResponse` was being piped through `Effect.tapCause`).

**`frontend/components/TextField.vue`** — move `v-bind="$props"` before the explicit `:type` binding so the computed `number`/`text` type wins instead of being overridden by an incoming `$props.type`.

No changeset included — the repo has no `.changeset/` setup; happy to add one if preferred.